### PR TITLE
ウィンドウの透明化とオブジェクトのドラッグを可能にするスクリプトを送ります

### DIFF
--- a/Assets/scripts/drag.cs
+++ b/Assets/scripts/drag.cs
@@ -1,0 +1,34 @@
+using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+
+public class drag : MonoBehaviour
+{
+    // 追加
+    private Vector3 screenPoint;
+    private Vector3 offset;
+    // Start is called before the first frame update
+    void Start()
+    {
+        
+    }
+
+    // Update is called once per frame
+    void Update()
+    {
+        
+    }
+    // 追加
+    void OnMouseDown()
+    {
+        this.screenPoint = Camera.main.WorldToScreenPoint(transform.position);
+        this.offset = transform.position - Camera.main.ScreenToWorldPoint(new Vector3(Input.mousePosition.x, Input.mousePosition.y, screenPoint.z));
+    }
+    // 追加
+    void OnMouseDrag()
+    {
+        Vector3 currentScreenPoint = new Vector3(Input.mousePosition.x, Input.mousePosition.y, screenPoint.z);
+        Vector3 currentPosition = Camera.main.ScreenToWorldPoint(currentScreenPoint) + this.offset;
+        transform.position = currentPosition;
+    }
+}

--- a/Assets/scripts/transparent.cs
+++ b/Assets/scripts/transparent.cs
@@ -1,0 +1,60 @@
+using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+using System.Runtime.InteropServices;
+using System;
+
+
+
+public class transparent : MonoBehaviour
+{
+#if UNITY_STANDALONE_WIN
+    [DllImport("user32.dll")]
+    static extern IntPtr GetActiveWindow();
+
+    [DllImport("user32.dll")]
+    static extern int SetWindowLong(IntPtr hWnd, int nIndex, uint dwNewLong);
+
+    [DllImport("user32.dll")]
+    static extern int SetWindowPos(IntPtr hWnd, int hWndInsertAfter, int x, int y, int cx, int cy, uint uFlags);
+
+    [DllImport("user32.dll")]
+    static extern int SetLayeredWindowAttributes(IntPtr hWnd, int crKey, byte bAlpha, uint dwFlags);
+
+
+    // Windows API declarations
+    private const int GWL_STYLE = -16;
+    private const uint WS_VISIBLE = 0x10000000;
+    private const uint WS_POPUP = 0x80000000;
+    private const uint HWND_TOPMOST = 0xFFFFFFFF;
+    private const uint SWP_NOMOVE = 0x2;
+	const int GWL_EXSTYLE = -20;
+	const uint WS_EX_LAYERED = 0x00080000;
+	const int LWA_COLORKEY = 1;
+#endif
+
+    // Start is called before the first frame update
+    void Start()
+    {
+#if !UNITY_EDITOR && UNITY_STANDALONE_WIN
+    int width = Screen.width;
+    int height = Screen.height;
+    var hWnd = GetActiveWindow();
+    SetWindowLong(hWnd, GWL_STYLE, WS_VISIBLE | WS_POPUP);
+    SetWindowPos(hWnd, -1/*HWND_TOPMOSTの代わり*/, 0, 0, width, height, SWP_NOMOVE);
+
+    SetWindowLong(hWnd, GWL_EXSTYLE, WS_EX_LAYERED);
+    SetLayeredWindowAttributes(hWnd, 0, 0, LWA_COLORKEY);
+#endif
+    }
+
+    // Update is called once per frame
+    void Update()
+    {
+    if (Input.GetKey(KeyCode.Escape))
+    {
+        Application.Quit();
+    }
+        
+    }
+}


### PR DESCRIPTION
# 概要
先日、Discordで話していたウィンドウの透明化用のスクリプトを送ります。
# 使い方
1. まず最初にプロジェクト設定を開きます。出てきた画面の左側メニューから「プレイヤー」を選択し、出てきた画面の中の「解像度と表示」メニューをクリックして開きます。
3. 「全画面モード」を「ウィンドウ化」に設定します。次に、「D3D11にDXGIフリップモデルスワップチェーン...」のチェックボックスがオフになっていない場合はオフにしておきます。
4. 以下の二つのスクリプトを美少女アバターのオブジェクトにアタッチしてください。スクリプトをアタッチするだけで動作するはずですが、もし実際にやってみて不具合が発生したらお知らせください。
## スクリプト概要
* **transparent.cs**: メインウィンドウを透明化させます。windows上のみで動作するため、それ以外の環境でビルドした場合には見た目に如何なる変化もありません。
* **drag.cs**: アタッチしたオブジェクトをマウスドラッグで移動できるようにします。